### PR TITLE
Rewrite box

### DIFF
--- a/include/vm/box.hpp
+++ b/include/vm/box.hpp
@@ -40,6 +40,7 @@ namespace salmon::vm {
 
 		template<typename T>
 		void set_value(T *value) {
+			static_assert(std::is_base_of<AllocatedItem, T>::value);
 			elem = value;
 			smart_ptr = value;
 		}

--- a/include/vm/box.hpp
+++ b/include/vm/box.hpp
@@ -46,6 +46,12 @@ namespace salmon::vm {
 		}
 
 		template<typename T>
+		void set_value(const vm_ptr<T> &value) {
+			elem = &*value;
+			smart_ptr = &*value;
+		}
+
+		template<typename T>
 		void set_value(T value) {
 			elem = value;
 			smart_ptr = nullptr;

--- a/include/vm/box.hpp
+++ b/include/vm/box.hpp
@@ -32,7 +32,13 @@ namespace salmon::vm {
 
 	struct Box : public InternalBox {
 
-		Box(std::unordered_map<AllocatedItem*,unsigned int> &table);
+		template<typename T>
+		Box(const vm_ptr<T> &elem_ptr) :
+			smart_ptr{elem_ptr} {
+			if(elem_ptr) {
+				elem = elem_ptr.get();
+			}
+		}
 		Box(const Box&) = default;
 		Box(Box &&) = default;
 		Box() = delete;
@@ -41,7 +47,7 @@ namespace salmon::vm {
 
 		template<typename T>
 		void set_value(const vm_ptr<T> &value) {
-			elem = &*value;
+			elem = value.get();
 			smart_ptr = &*value;
 		}
 

--- a/include/vm/box.hpp
+++ b/include/vm/box.hpp
@@ -16,16 +16,17 @@ namespace salmon::vm {
 	struct List;
 	struct Array;
 
+	using BoxVariant = std::variant<int32_t,
+									float,
+									bool,
+									Empty,
+									Symbol*,
+									List*,
+									StaticString*>;
+
 	struct InternalBox {
 		TypePtr type;
-		std::variant<int32_t,
-					 float,
-					 bool,
-					 Empty,
-					 Symbol*,
-					 List*,
-					 StaticString*>
-					 elem;
+		BoxVariant elem;
 		std::vector<AllocatedItem*> get_roots() const;
 	};
 

--- a/include/vm/box.hpp
+++ b/include/vm/box.hpp
@@ -20,6 +20,7 @@ namespace salmon::vm {
 									float,
 									bool,
 									Empty,
+									Array*,
 									Symbol*,
 									List*,
 									StaticString*>;

--- a/include/vm/box.hpp
+++ b/include/vm/box.hpp
@@ -40,13 +40,6 @@ namespace salmon::vm {
 		Box &operator=(const Box &) = default;
 
 		template<typename T>
-		void set_value(T *value) {
-			static_assert(std::is_base_of<AllocatedItem, T>::value);
-			elem = value;
-			smart_ptr = value;
-		}
-
-		template<typename T>
 		void set_value(const vm_ptr<T> &value) {
 			elem = &*value;
 			smart_ptr = &*value;

--- a/include/vm/box.hpp
+++ b/include/vm/box.hpp
@@ -31,15 +31,27 @@ namespace salmon::vm {
 
 	struct Box : public InternalBox {
 
-		Box(std::unordered_set<Box*> &table);
-		Box(const Box&);
+		Box(std::unordered_map<AllocatedItem*,unsigned int> &table);
+		Box(const Box&) = default;
+		Box(Box &&) = default;
 		Box() = delete;
-		~Box();
 
-		Box &operator=(const Box &);
+		Box &operator=(const Box &) = default;
+
+		template<typename T>
+		void set_value(T *value) {
+			elem = value;
+			smart_ptr = value;
+		}
+
+		template<typename T>
+		void set_value(T value) {
+			elem = value;
+			smart_ptr = nullptr;
+		}
 
 	private:
-		std::unordered_set<Box*> *instances;
+		vm_ptr<AllocatedItem> smart_ptr;
 	};
 
 	struct Array : public AllocatedItem {

--- a/include/vm/memory.hpp
+++ b/include/vm/memory.hpp
@@ -19,9 +19,13 @@ namespace salmon::vm {
 		~MemoryManager();
 
 		// While it may be possible to copy a MemoryManager, the default implementation is wrong:
-		MemoryManager(const Package&) = delete;
+		MemoryManager(const MemoryManager&) = delete;
 
-		Box make_box();
+		template<typename T>
+		vm_ptr<T> make_vm_ptr() {
+			vm_ptr<T> tmp(nullptr, roots);
+			return tmp;
+		}
 
 		template<typename T, typename ... ConstructorArgs>
 		vm_ptr<T> allocate_obj(ConstructorArgs... args) {

--- a/include/vm/memory.hpp
+++ b/include/vm/memory.hpp
@@ -37,7 +37,6 @@ namespace salmon::vm {
 		std::unordered_set<AllocatedItem*> allocated;
 		//! reference count of allocated objects kept track of using vm_ptrs
 		std::unordered_map<AllocatedItem*, unsigned int> roots;
-		std::unordered_set<Box*> box_roots;
 		size_t total_allocated;
 	};
 }

--- a/include/vm/vm_ptr.hpp
+++ b/include/vm/vm_ptr.hpp
@@ -22,6 +22,8 @@ namespace salmon::vm {
 
 	public:
 
+		template<typename> friend class vm_ptr;
+
 		explicit vm_ptr(T *thing, std::unordered_map<AllocatedItem*, unsigned int> &table) :
 		    instances{&table},
 			ptr(thing) {
@@ -37,6 +39,18 @@ namespace salmon::vm {
 		vm_ptr(const vm_ptr<T>& other) :
 			instances{other.instances},
 			ptr(other.ptr) {
+			// Unless we point to something, don't do anything:
+			if(ptr) {
+				auto pos = instances->find(ptr);
+				pos->second += 1;
+			}
+		}
+
+		template<typename Other>
+		vm_ptr(const vm_ptr<Other> other) :
+			instances{other.instances},
+			ptr(static_cast<T*>(other.get())) {
+			static_assert(std::is_base_of<T, Other>::value);
 			// Unless we point to something, don't do anything:
 			if(ptr) {
 				auto pos = instances->find(ptr);

--- a/include/vm/vm_ptr.hpp
+++ b/include/vm/vm_ptr.hpp
@@ -96,6 +96,20 @@ namespace salmon::vm {
 			return *this;
 		}
 
+		vm_ptr& operator=(std::nullptr_t)  {
+			// Maybe just call the destructor?
+			// This is copied from that
+			if(ptr) {
+				auto pos = instances->find(ptr);
+				pos->second -= 1;
+				if(pos->second == 0) {
+					instances->erase(pos);
+				}
+				ptr = nullptr;
+			}
+			return *this;
+		}
+
 		T* get() const {
 			return ptr;
 		}

--- a/include/vm/vm_ptr.hpp
+++ b/include/vm/vm_ptr.hpp
@@ -88,9 +88,9 @@ namespace salmon::vm {
 			return *this;
 		}
 
-		vm_ptr& operator=(T* newPtr)  {
+		vm_ptr& operator=(T *newPtr)  {
 			if(ptr != newPtr) {
-				vm_ptr tmp(newPtr);
+				vm_ptr tmp(newPtr, std::ref(*instances));
 				tmp.swap(*this);
 			}
 			return *this;

--- a/salmon/compiler/parser.cpp
+++ b/salmon/compiler/parser.cpp
@@ -144,10 +144,9 @@ namespace salmon::compiler {
 
 	end:
 
-		salmon::vm::Box box = compiler.vm.mem_manager.make_box();
-		box.type = compiler.vm.const_str_type();
 		auto str = compiler.vm.mem_manager.allocate_obj<vm::StaticString>(token.str());
-		box.set_value(std::move(str));
+		vm::Box box(str);
+		box.type = compiler.vm.const_str_type();
 
 		return box;
 	}
@@ -212,10 +211,9 @@ namespace salmon::compiler {
 			throw ParseException("Encountered package prefix or keyword while parsing reader macro #:",
 								 start_info, countStreamBuf->positionInfo());
 		} else {
-			vm::Box box = compiler.vm.mem_manager.make_box();
 			vm::vm_ptr<vm::Symbol> tmp_symb = compiler.vm.mem_manager.allocate_obj<vm::Symbol>(chunk);
+			vm::Box box(tmp_symb);
 			box.type = compiler.vm.symbol_type();
-			box.set_value(std::move(tmp_symb));
 			return box;
 		}
 	}
@@ -282,7 +280,7 @@ namespace salmon::compiler {
 		}
 
 		// TODO: add unsigned integers:
-		salmon::vm::Box box = compiler.vm.mem_manager.make_box();
+		vm::Box box(compiler.vm.mem_manager.make_vm_ptr<vm::AllocatedItem>());
 		box.set_value(static_cast<int32_t>(sum));
 		box.type = compiler.vm.int32_type();
 		return box;
@@ -324,7 +322,7 @@ namespace salmon::compiler {
 		std::string chunk = read_atom(input);
 		salmon_check(!chunk.empty(), "Atom shouldn't be empty");
 
-		salmon::vm::Box box = compiler.vm.mem_manager.make_box();
+		salmon::vm::Box box(compiler.vm.mem_manager.make_vm_ptr<vm::AllocatedItem>());
 		if(NumberType type = get_num_type(chunk); type != NumberType::NOT_A_NUM) {
 			switch(type) {
 			case NumberType::FLOAT:
@@ -340,11 +338,11 @@ namespace salmon::compiler {
 			}
 		} else if(isKeyword(chunk)) {
 			auto symb = compiler.keyword_package()->intern_symbol(chunk.substr(1));
-			box.set_value(std::move(symb));
+			box.set_value(symb);
 			box.type = compiler.vm.symbol_type();
 		} else {
 			auto symb = compiler.current_package()->intern_symbol(chunk);
-			box.set_value(std::move(symb));
+			box.set_value(symb);
 			box.type = compiler.vm.symbol_type();
 		}
 
@@ -400,12 +398,11 @@ namespace salmon::compiler {
 				tail->next = &*next;
 				tail = next;
 			}
-			vm::Box box = compiler.vm.mem_manager.make_box();
-			box.set_value(std::move(head));
+			vm::Box box(head);
 			box.type = compiler.vm.list_type();
 			return box;
 		} else {
-			vm::Box box = compiler.vm.mem_manager.make_box();
+			vm::Box box(compiler.vm.mem_manager.make_vm_ptr<vm::AllocatedItem>());
 			vm::Empty empty;
 			box.type = compiler.vm.empty_type();
 			box.set_value(empty);
@@ -419,8 +416,7 @@ namespace salmon::compiler {
 		for(salmon::vm::Box &box : collected_items) {
 			array->items.push_back(box);
 		}
-		vm::Box box = compiler.vm.mem_manager.make_box();
-		box.set_value(std::move(array));
+		vm::Box box(array);
 		box.type = compiler.vm.dyn_array_type();
 		return box;
 	}

--- a/salmon/compiler/parser.cpp
+++ b/salmon/compiler/parser.cpp
@@ -146,7 +146,8 @@ namespace salmon::compiler {
 
 		salmon::vm::Box box = compiler.vm.mem_manager.make_box();
 		box.type = compiler.vm.const_str_type();
-		box.elem = &*compiler.vm.mem_manager.allocate_obj<vm::StaticString>(token.str());
+		auto str = compiler.vm.mem_manager.allocate_obj<vm::StaticString>(token.str());
+		box.set_value(std::move(str));
 
 		return box;
 	}
@@ -214,7 +215,7 @@ namespace salmon::compiler {
 			vm::Box box = compiler.vm.mem_manager.make_box();
 			vm::vm_ptr<vm::Symbol> tmp_symb = compiler.vm.mem_manager.allocate_obj<vm::Symbol>(chunk);
 			box.type = compiler.vm.symbol_type();
-			box.elem = &*tmp_symb;
+			box.set_value(std::move(tmp_symb));
 			return box;
 		}
 	}
@@ -282,7 +283,7 @@ namespace salmon::compiler {
 
 		// TODO: add unsigned integers:
 		salmon::vm::Box box = compiler.vm.mem_manager.make_box();
-		box.elem = static_cast<int32_t>(sum);
+		box.set_value(static_cast<int32_t>(sum));
 		box.type = compiler.vm.int32_type();
 		return box;
 	}
@@ -327,11 +328,11 @@ namespace salmon::compiler {
 		if(NumberType type = get_num_type(chunk); type != NumberType::NOT_A_NUM) {
 			switch(type) {
 			case NumberType::FLOAT:
-				box.elem = std::stof(chunk);
+				box.set_value(std::stof(chunk));
 				box.type = compiler.vm.float_type();
 				break;
 			case NumberType::INTEGER:
-				box.elem = std::stoi(chunk);
+				box.set_value(std::stoi(chunk));
 				box.type = compiler.vm.int32_type();
 				break;
 			case NumberType::NOT_A_NUM:
@@ -339,11 +340,11 @@ namespace salmon::compiler {
 			}
 		} else if(isKeyword(chunk)) {
 			auto symb = compiler.keyword_package()->intern_symbol(chunk.substr(1));
-			box.elem = &*symb;
+			box.set_value(std::move(symb));
 			box.type = compiler.vm.symbol_type();
 		} else {
 			auto symb = compiler.current_package()->intern_symbol(chunk);
-			box.elem = &*symb;
+			box.set_value(std::move(symb));
 			box.type = compiler.vm.symbol_type();
 		}
 
@@ -400,14 +401,14 @@ namespace salmon::compiler {
 				tail = next;
 			}
 			vm::Box box = compiler.vm.mem_manager.make_box();
-			box.elem = &*head;
+			box.set_value(std::move(head));
 			box.type = compiler.vm.list_type();
 			return box;
 		} else {
 			vm::Box box = compiler.vm.mem_manager.make_box();
 			vm::Empty empty;
 			box.type = compiler.vm.empty_type();
-			box.elem = empty;
+			box.set_value(empty);
 			return box;
 		}
 	}
@@ -419,7 +420,7 @@ namespace salmon::compiler {
 			array->items.push_back(box);
 		}
 		vm::Box box = compiler.vm.mem_manager.make_box();
-		box.elem = &*array;
+		box.set_value(std::move(array));
 		box.type = compiler.vm.dyn_array_type();
 		return box;
 	}

--- a/salmon/main.cpp
+++ b/salmon/main.cpp
@@ -14,7 +14,6 @@
 #include <salmon/config.hpp>
 #include <compiler/compiler.hpp>
 
-
 static salmon::Config get_config() {
 	return {
 		0, salmon::get_cache_dir(), salmon::get_config_dir(), salmon::get_data_dir()

--- a/salmon/vm/box.cpp
+++ b/salmon/vm/box.cpp
@@ -19,35 +19,6 @@ namespace salmon::vm {
 			} }, elem);
 	}
 
-	Box::Box(std::unordered_set<Box*> &table) :
-		instances{&table} {
-	    [[maybe_unused]] auto [pos, newly_added] = instances->insert(this);
-		salmon_check(newly_added, "Box wasn't added to the box table");
-	}
-
-	Box::Box(const Box &other) :
-		InternalBox(other),
-		instances{other.instances}  {
-		salmon_check(instances != nullptr, "Box constructor expects a valid table");
-		[[maybe_unused]] auto [pos, newly_added] = instances->insert(this);
-		salmon_check(newly_added, "Box wasn't added to the box table");
-	}
-
-	Box::~Box() {
-		salmon_check(instances != nullptr, "Box constructor should have a valid table");
-		auto pos = instances->find(this);
-		salmon_check(pos != instances->end(), "Deleted box isn't in the box table");
-		instances->erase(pos);
-	}
-
-	Box & Box::operator=(const Box &other) {
-		if(this != &other) {
-			// ensure the current box is registered:
-			instances->insert(this);
-			elem = other.elem;
-			type = other.type;
-			instances = other.instances;
-		}
-		return *this;
-	}
+	Box::Box(std::unordered_map<AllocatedItem*,unsigned int> &table) :
+		smart_ptr(nullptr, table) { }
 }

--- a/salmon/vm/box.cpp
+++ b/salmon/vm/box.cpp
@@ -18,7 +18,4 @@ namespace salmon::vm {
 				return set;
 			} }, elem);
 	}
-
-	Box::Box(std::unordered_map<AllocatedItem*,unsigned int> &table) :
-		smart_ptr(nullptr, table) { }
 }

--- a/salmon/vm/memory.cpp
+++ b/salmon/vm/memory.cpp
@@ -16,7 +16,7 @@ namespace salmon::vm {
 	}
 
 	Box MemoryManager::make_box() {
-		Box box(box_roots);
+		Box box(roots);
 		return box;
 	}
 
@@ -57,16 +57,6 @@ namespace salmon::vm {
 			// each root is guaranteed to be unique, so no need to check if it has
 			// already been marked.
 		    check_item(root, to_check, marked);
-		}
-
-		for(Box *box : box_roots) {
-			std::vector<AllocatedItem*> children = box->get_roots();
-			for(AllocatedItem *child : children) {
-				// ensure that marked union to_check = ()
-				if(!set_contains(marked, child)) {
-					to_check.insert(child);
-				}
-			}
 		}
 
 		while (!to_check.empty()) {

--- a/salmon/vm/memory.cpp
+++ b/salmon/vm/memory.cpp
@@ -16,11 +16,6 @@ namespace salmon::vm {
 		do_gc();
 	}
 
-	Box MemoryManager::make_box() {
-		Box box(roots);
-		return box;
-	}
-
 	static bool set_contains(const std::unordered_set<AllocatedItem*> &set, AllocatedItem* item) {
 		auto itr = set.find(item);
 		return itr != set.end();

--- a/salmon/vm/memory.cpp
+++ b/salmon/vm/memory.cpp
@@ -13,6 +13,7 @@ namespace salmon::vm {
 
 	MemoryManager::~MemoryManager() {
 		do_gc();
+		do_gc();
 	}
 
 	Box MemoryManager::make_box() {

--- a/test/vm/builtin_function_test.cpp
+++ b/test/vm/builtin_function_test.cpp
@@ -24,15 +24,16 @@ namespace salmon::vm {
 	SCENARIO("Builtin functions check their argument lengths", "[vm, functions]") {
 
 		WHEN("The wrong number of arguments is given") {
-
-			Box b = manager.make_box();
+			auto ptr = manager.make_vm_ptr<AllocatedItem>();
+			Box b(ptr);
 			std::vector<Box> input = { b };
 			THEN("An ArityException is thrown") {
 				REQUIRE_THROWS_AS(func(input), ArityException);
 			}
 		}
 		WHEN("The correct number of arguments is given") {
-			Box b = manager.make_box();
+			auto ptr = manager.make_vm_ptr<AllocatedItem>();
+			Box b(ptr);
 			std::vector<Box> input = { b, b };
 			THEN("An ArityException isn't thrown") {
 				REQUIRE_NOTHROW(func(input));
@@ -42,7 +43,8 @@ namespace salmon::vm {
 
 	SCENARIO("ArityExceptions report the correct info", "[vm, functions]") {
 		try {
-			Box b = manager.make_box();
+			auto ptr = manager.make_vm_ptr<AllocatedItem>();
+			Box b(ptr);
 			std::vector<Box> input = { b };
 			func(input);
 			REQUIRE(false);


### PR DESCRIPTION
Improves the design of vm::Box by using `vm::vm_ptr` under the hood, and adds some convenience functions.